### PR TITLE
remove --fail-fast flag

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --color
 --format documentation
---fail-fast
 --require spec_helper


### PR DESCRIPTION
Had to walk a student through making this modification in their fork. Seems like it should default to not `--fail-fast` like every other lab.

cc: @aturkewi 